### PR TITLE
allow building images not called 'schlomo'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ info:
 rpm:
 	mkdir -p $(WORK_DIR)/BUILD
 	docker save $(IMAGE) >$(WORK_DIR)/image
-	sed <service.sh >$(WORK_DIR)/service.sh -e "s/REPLACE_IMAGE/$(IMAGE)/g" -e "s/REPLACE_NAME/$(NAME)/g" -e 's/REPLACE_RUNARGS/$(RUNARGS)/g'
+	sed <service.sh >$(WORK_DIR)/service.sh -e "s/REPLACE_IMAGE/$(echo $IMAGE | sed 's/\//\\\//g')/g" -e "s/REPLACE_NAME/$NAME/g" -e 's/REPLACE_RUNARGS/$(RUNARGS)/g'
 	cp service.spec $(WORK_DIR)/$(NAME).spec
-	rpmbuild -bb -D "image $(IMAGE)" -D "name $(NAME)" -D "version $(VERSION)" -D "release $(RELEASE)" -D "requires $(REQUIRES)" -D "_topdir $(WORK_DIR)" -D "_sourcedir %_topdir" -D "_rpmdir %_topdir" -D "_target_os linux" $(WORK_DIR)/schlomo.spec
+	rpmbuild -bb -D "image $(IMAGE)" -D "name $(NAME)" -D "version $(VERSION)" -D "release $(RELEASE)" -D "requires $(REQUIRES)" -D "_topdir $(WORK_DIR)" -D "_sourcedir %_topdir" -D "_rpmdir %_topdir" -D "_target_os linux" $(WORK_DIR)/$(NAME).spec
 	mv $(WORK_DIR)/noarch/$(NAME)*rpm .
 	rm -Rf $(WORK_DIR)
 	@echo


### PR DESCRIPTION
There's a hardcoded `schlomo.spec` in there.
Also if the image name contains slashes 
(`bomgar/jupyter-scala-notebook`) then these
slashes need to be escaped lest they break
the sed expression.
